### PR TITLE
Fixing the strict warning because of parameter mismatch on sendRequest.

### DIFF
--- a/lib/encoding/getstatus.php
+++ b/lib/encoding/getstatus.php
@@ -25,7 +25,7 @@ class Encoding_GetStatusAction extends Encoding_Client {
   /**
    * Implements parent::sendRequest().
    */
-  public function sendRequest() {
+  public function sendRequest($method) {
     return parent::sendRequest(Encoding_Client::POST);
   }
 }


### PR DESCRIPTION
![thumbs_up](http://media1.giphy.com/media/nX1yKT9Wv1ZDO/200.gif)
